### PR TITLE
Fix account sorting issue

### DIFF
--- a/D2Loader.ps1
+++ b/D2Loader.ps1
@@ -2328,7 +2328,7 @@ Function DisplayActiveAccounts {
 		Write-Host "  ID   Account Label"
 	}
 	$Pattern = "(?<=- [^\(]+ \()([a-z]+)" #Regex pattern to pull the region characters out of the window title.
-	foreach ($AccountOption in ($Script:AccountOptionsCSV | Sort-Object -Property @{Expression = {[int]$_.ID}} )){
+	foreach ($AccountOption in ($Script:AccountOptionsCSV | Sort-Object -Property @{Expression = {$_.ID}} )){
 		$RegionDisplayPostIndent = ""
 		$RegionDisplayPreIndent = ""
 		if ($AccountOption.ID.length -ge 2){#keep table formatting looking lovely if some crazy user has 10+ accounts.


### PR DESCRIPTION
The sorting of accounts casts the ID to int which in turn blows up if any of the IDs are not numbers.

Removing the cast fixes the issue.